### PR TITLE
Clarify ReAct prompt instructions

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -196,6 +196,9 @@ Final Answer: [your answer]
 
 Available tools: read_file, write_file, list_directory, execute_command, system_info
 
+Keep reasoning concise, avoid repeating prior thoughts.
+Final Answer must include all requested information without referring to earlier reasoning.
+
 Begin reasoning."""
             )
             


### PR DESCRIPTION
## Summary
- In ReAct prompt, instruct the model to keep reasoning concise and avoid repeating prior thoughts
- Require final answers to include all requested information without referencing earlier reasoning

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d9a09d3e8832daf1f5d126b33e2a6