### PR TITLE
Include latest tool output in ReAct final response

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -201,7 +201,9 @@ Begin reasoning."""
             
             # Start conversation with ReAct prompt
             self.conversation_history = messages + [{"role": "user", "content": react_prompt}]
-            
+            # Keep track of most recent tool output
+            last_tool_result = ""
+
             for iteration in range(self.max_iterations):
                 async with cl.Step(name=f"Reasoning Cycle {iteration + 1}", type="run") as iter_step:
                     
@@ -220,6 +222,9 @@ Begin reasoning."""
                     # Check for Final Answer
                     if "Final Answer:" in llm_response:
                         final_answer = llm_response.split("Final Answer:")[-1].strip()
+                        # Append last tool result if not already included
+                        if last_tool_result and last_tool_result not in final_answer:
+                            final_answer = f"{final_answer}\n\n{last_tool_result}"
                         iter_step.output = f"✅ Final answer reached"
                         main_step.output = f"✅ Completed in {iteration + 1} iterations"
                         return final_answer
@@ -232,6 +237,8 @@ Begin reasoning."""
                                 action_step.input = f"Tool: {tool_call['name']}"
                                 result = await execute_tool_call(tool_call['name'], tool_call['arguments'])
                                 action_step.output = result
+                                # Store most recent tool result
+                                last_tool_result = result
                                 
                                 # Add observation to conversation
                                 self.conversation_history.append({"role": "assistant", "content": llm_response})


### PR DESCRIPTION
## Summary
- Track most recent tool result during ReAct reasoning
- Append stored tool result to `Final Answer` when missing
- Return combined answer and result for display

## Testing
- `python -m py_compile src/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689d9ae6d6c0832dbd28117c62605b72