### PR TITLE
Refine ReAct trigger logic and add tests

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -162,14 +162,14 @@ class ReActAgent:
             'what files', 'how many', 'count', 'size'
         ]
         
-        # Multi-word questions often need reasoning
+        # Only engage ReAct when query is long AND contains a complexity keyword
         word_count = len(query.split())
-        
+
         query_lower = query.lower()
         has_complexity = any(indicator in query_lower for indicator in complexity_indicators)
         is_multi_step = word_count > 6
-        
-        return has_complexity or is_multi_step
+
+        return has_complexity and is_multi_step
     
     async def _execute_react_loop(self, query: str, messages: List[Dict]) -> str:
         """Execute ReAct reasoning loop - let qwen3-14b think and act"""

--- a/tests/test_react_agent.py
+++ b/tests/test_react_agent.py
@@ -1,0 +1,61 @@
+import sys
+import types
+from pathlib import Path
+
+# Add src directory to path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+# Stub external dependencies
+class DummyStep:
+    def __init__(self, *args, **kwargs):
+        self.input = None
+        self.output = None
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def stream_token(self, token):
+        pass
+
+class DummyMessage:
+    def __init__(self, content=""):
+        self.content = content
+    async def send(self):
+        pass
+
+class DummyUserSession(dict):
+    def set(self, key, value):
+        self[key] = value
+    def get(self, key, default=None):
+        return super().get(key, default)
+
+def _decorator(func):
+    return func
+
+sys.modules['chainlit'] = types.SimpleNamespace(
+    Step=DummyStep,
+    Message=DummyMessage,
+    user_session=DummyUserSession(),
+    on_chat_start=_decorator,
+    on_message=_decorator,
+    on_stop=_decorator,
+)
+
+class DummyAsyncClient:
+    async def chat(self, *args, **kwargs):
+        yield {"message": {"content": ""}}
+
+sys.modules['ollama'] = types.SimpleNamespace(AsyncClient=lambda: DummyAsyncClient())
+
+from app import ReActAgent
+
+
+def test_simple_query_bypasses_react():
+    agent = ReActAgent()
+    assert agent._needs_react_reasoning("What tools do you have available?") is False
+
+
+def test_complex_query_triggers_react():
+    agent = ReActAgent()
+    query = "Can you analyze and compare the sizes of files in the directory?"
+    assert agent._needs_react_reasoning(query) is True


### PR DESCRIPTION
## Summary
- Require both a complexity keyword and more than six words before invoking the ReAct reasoning loop
- Add unit tests confirming that simple questions like "What tools do you have available?" bypass ReAct

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689db53819d0832db6e39f6cfb6116ba