### PR TITLE
Enforce complexity detection before using ReAct framework

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -167,12 +167,13 @@ class ReActAgent:
         
         # Only engage ReAct when query is long AND contains a complexity keyword
         word_count = len(query.split())
+        if word_count <= 6:
+            return False
 
         query_lower = query.lower()
         has_complexity = any(indicator in query_lower for indicator in complexity_indicators)
-        is_multi_step = word_count > 6
 
-        return has_complexity and is_multi_step
+        return has_complexity
     
     async def _execute_react_loop(self, query: str, messages: List[Dict]) -> str:
         """Execute ReAct reasoning loop - let qwen3-14b think and act"""

--- a/tests/test_react_agent.py
+++ b/tests/test_react_agent.py
@@ -49,10 +49,15 @@ sys.modules['ollama'] = types.SimpleNamespace(AsyncClient=lambda: DummyAsyncClie
 
 from app import ReActAgent
 
-
 def test_simple_query_bypasses_react():
     agent = ReActAgent()
-    assert agent._needs_react_reasoning("What tools do you have available?") is False
+    assert agent._needs_react_reasoning("What tools do you have?") is False
+
+
+def test_long_simple_query_bypasses_react():
+    agent = ReActAgent()
+    query = "I am curious about the tools you have in this environment today"
+    assert agent._needs_react_reasoning(query) is False
 
 
 def test_complex_query_triggers_react():


### PR DESCRIPTION
## Summary
- Ensure `_needs_react_reasoning` only triggers when a query contains a complexity keyword *and* is longer than six words
- Add tests verifying that simple prompts like "What tools do you have?" and other long but simple queries bypass ReAct

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc4a37348832db86ca93d07239fa3