### PR TITLE
Stream Ollama responses to Chainlit

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -217,12 +217,13 @@ Begin reasoning."""
                     # Stream response tokens
                     async with cl.Step(name="🤔 Thinking", type="llm") as thought_step:
                         llm_response = ""
-                        async for chunk in await ollama.AsyncClient().chat(
+                        stream = await ollama.AsyncClient().chat(
                             model=MODEL_NAME,
                             messages=self.conversation_history,
                             stream=True,
                             options={**QWEN3_PARAMS, "keep_alive": -1}
-                        ):
+                        )
+                        async for chunk in stream:
                             token = chunk.get('message', {}).get('content', '')
                             if token:
                                 await thought_step.stream_token(token)
@@ -284,12 +285,13 @@ Begin reasoning."""
             # Stream response tokens
             async with cl.Step(name="💬 Response", type="llm") as answer_step:
                 llm_response = ""
-                async for chunk in await ollama.AsyncClient().chat(
+                stream = await ollama.AsyncClient().chat(
                     model=MODEL_NAME,
                     messages=messages + [{"role": "user", "content": query}],
                     stream=True,
                     options={**QWEN3_PARAMS, "keep_alive": -1}
-                ):
+                )
+                async for chunk in stream:
                     token = chunk.get('message', {}).get('content', '')
                     if token:
                         await answer_step.stream_token(token)


### PR DESCRIPTION
## Summary
- Stream tokens from Ollama for both reasoning and simple responses, forwarding each token to Chainlit as it arrives.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dc4ab5ea0832daf5c01ad6924f7cb