### PR TITLE
Use system role for internal ReAct context messages

### DIFF
--- a/src/app-backup.py
+++ b/src/app-backup.py
@@ -226,14 +226,21 @@ Begin:"""
                                 result = await execute_tool_call(tool_call['name'], tool_call['arguments'])
                                 action_step.output = result
                                 
-                                # Add observation to conversation
+                                # Add observation to conversation as internal context
                                 self.conversation_history.append({"role": "assistant", "content": llm_response})
-                                self.conversation_history.append({"role": "user", "content": f"Observation: {result}\n\nContinue reasoning:"})
+                                self.conversation_history.append(
+                                    {
+                                        "role": "system",
+                                        "content": f"Observation: {result}\n\nContinue reasoning:",
+                                    }
+                                )
                                 break
                     else:
                         # No tool call, continue reasoning
                         self.conversation_history.append({"role": "assistant", "content": llm_response})
-                        self.conversation_history.append({"role": "user", "content": "Continue with your reasoning:"})
+                        self.conversation_history.append(
+                            {"role": "system", "content": "Continue with your reasoning:"}
+                        )
                     
                     iter_step.output = f"Iteration {iteration + 1} completed"
             

--- a/src/app.py
+++ b/src/app.py
@@ -253,7 +253,13 @@ Begin reasoning."""
 
                                 # Add observation to conversation
                                 self.conversation_history.append({"role": "assistant", "content": llm_response})
-                                self.conversation_history.append({"role": "user", "content": f"Observation: {result}\n\nContinue reasoning:"})
+                                # Store tool output as internal context for the next cycle
+                                self.conversation_history.append(
+                                    {
+                                        "role": "system",
+                                        "content": f"Observation: {result}\n\nContinue reasoning:",
+                                    }
+                                )
                                 break
                     else:
                         # No tool call present. If the model responded directly (no "Thought:" prefix),
@@ -268,7 +274,10 @@ Begin reasoning."""
 
                         # Otherwise, continue reasoning cycle
                         self.conversation_history.append({"role": "assistant", "content": llm_response})
-                        self.conversation_history.append({"role": "user", "content": "Continue with your reasoning:"})
+                        # Prompt model to continue reasoning using a system message
+                        self.conversation_history.append(
+                            {"role": "system", "content": "Continue with your reasoning:"}
+                        )
                     
                     iter_step.output = f"Iteration {iteration + 1} completed"
             


### PR DESCRIPTION
## Summary
- treat tool observations as system messages instead of user prompts
- send follow-up prompts with system role to keep ReAct context internal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc4aeb4d0832d9561730b00bf53bc