### PR TITLE
Handle action-syntax tool calls in ReAct loop

### DIFF
--- a/tests/test_parse_hermes_tool_calls.py
+++ b/tests/test_parse_hermes_tool_calls.py
@@ -1,0 +1,31 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+# Stub external dependencies required by app module
+sys.modules.setdefault(
+    'chainlit',
+    types.SimpleNamespace(
+        Step=None,
+        on_chat_start=lambda f: f,
+        on_message=lambda f: f,
+        on_stop=lambda f: f,
+        Message=None,
+        user_session=None,
+    ),
+)
+sys.modules.setdefault('ollama', types.SimpleNamespace(AsyncClient=None))
+
+from app import parse_hermes_tool_calls
+
+
+def test_parse_action_fallback():
+    response = (
+        'Thought: consider file\n'
+        'Action: read_file\n'
+        'Action Input: {"path": "foo.txt"}\n'
+    )
+    tool_calls = parse_hermes_tool_calls(response)
+    assert tool_calls == [{"name": "read_file", "arguments": {"path": "foo.txt"}}]

--- a/tests/test_react_loop.py
+++ b/tests/test_react_loop.py
@@ -46,12 +46,12 @@ class DummyStep:
 
 
 class DummyAsyncClient:
-    """Mock of ollama.AsyncClient streaming a preset response."""
+    """Mock of ollama.AsyncClient streaming preset responses per call."""
 
-    tokens = []
+    responses = []
 
     def chat(self, model, messages, stream, options):
-        tokens = list(self.tokens)
+        tokens = list(self.responses.pop(0) if self.responses else [])
 
         class Response:
             def __init__(self, toks):
@@ -63,7 +63,7 @@ class DummyAsyncClient:
                 return _wrap().__await__()
 
             def __aiter__(self):
-                async def gen():
+                async def gen():  # pragma: no cover - behaviour not tested
                     for t in self.toks:
                         yield {"message": {"content": t}}
                 return gen()
@@ -76,7 +76,7 @@ def test_direct_answer_exits_in_one_iteration(monkeypatch):
     monkeypatch.setattr(app.ollama, "AsyncClient", DummyAsyncClient)
 
     DummyStep.calls = []
-    DummyAsyncClient.tokens = ["Paris is the capital of France."]
+    DummyAsyncClient.responses = [["Paris is the capital of France."]]
 
     agent = ReActAgent()
     result = asyncio.run(agent._execute_react_loop("What is the capital of France?", []))
@@ -84,4 +84,22 @@ def test_direct_answer_exits_in_one_iteration(monkeypatch):
     assert result == "Paris is the capital of France."
     reasoning_cycles = [n for n in DummyStep.calls if n and n.startswith("Reasoning Cycle")]
     assert len(reasoning_cycles) == 1
+
+
+def test_rejects_fake_observation(monkeypatch):
+    monkeypatch.setattr(app, "cl", types.SimpleNamespace(Step=DummyStep))
+    monkeypatch.setattr(app.ollama, "AsyncClient", DummyAsyncClient)
+
+    DummyStep.calls = []
+    DummyAsyncClient.responses = [
+        ["Thought: check file\nAction: read_file\nAction Input: {\"path\": \"foo.txt\"}\nObservation: fake"],
+        ["Final Answer: done"],
+    ]
+
+    agent = ReActAgent()
+    result = asyncio.run(agent._execute_react_loop("Read file", []))
+
+    assert result.strip() == "done"
+    reasoning_cycles = [n for n in DummyStep.calls if n and n.startswith("Reasoning Cycle")]
+    assert len(reasoning_cycles) == 2
 


### PR DESCRIPTION
## Summary
- parse Hermes tool calls even when only `Action:`/`Action Input:` markers are present
- reject model responses that fabricate Observations or include unformatted action markers, prompting a retry
- add regression tests for parser fallback and self-observation rejection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc4b037d8832dafa7f2ad3247becd