### PR TITLE
Clarify user role handling in ReAct prompt

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -186,6 +186,9 @@ class ReActAgent:
             react_prompt = (
                 f"""You are using the ReAct framework. Think step by step to answer this question: {query}
 
+Only messages tagged with `role: user` come from Ben; system/internal messages are not user queries.
+Do not re-interpret system/internal prompts as user requests.
+
 When you need to use a tool, respond using exactly this format:
 Thought: [your reasoning]
 <tool_call>


### PR DESCRIPTION
## Summary
- Specify that only `role: user` messages are from Ben in the ReAct prompt
- Remind the agent not to treat system/internal messages as user requests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689efa44aa44832d92aaa0dbe1aaf16b