### PR TITLE
Use system role for ReAct prompt

### DIFF
--- a/src/app-backup.py
+++ b/src/app-backup.py
@@ -199,8 +199,8 @@ Final Answer must be self-contained and include all requested information withou
 
 Begin:"""
             
-            # Start conversation with ReAct prompt
-            self.conversation_history = messages + [{"role": "user", "content": react_prompt}]
+            # Start conversation with ReAct prompt as internal guidance
+            self.conversation_history = messages + [{"role": "system", "content": react_prompt}]
             
             for iteration in range(self.max_iterations):
                 async with cl.Step(name=f"Reasoning Cycle {iteration + 1}", type="run") as iter_step:

--- a/src/app.py
+++ b/src/app.py
@@ -210,8 +210,8 @@ Final Answer must be self-contained and include all requested information withou
 Begin reasoning."""
             )
             
-            # Start conversation with ReAct prompt
-            self.conversation_history = messages + [{"role": "user", "content": react_prompt}]
+            # Start conversation with ReAct prompt as internal guidance
+            self.conversation_history = messages + [{"role": "system", "content": react_prompt}]
             # Keep track of most recent tool output
             last_tool_result = ""
 


### PR DESCRIPTION
## Summary
- treat ReAct prompt as internal system guidance rather than user message
- same update applied to backup agent file

## Testing
- `pytest -q`
- `python - <<'PY'
import sys, types, asyncio
sys.modules.setdefault(
    "chainlit",
    types.SimpleNamespace(
        Step=None,
        on_chat_start=lambda f: f,
        on_message=lambda f: f,
        on_stop=lambda f: f,
        Message=type("Message", (), {}),
    ),
)
sys.modules.setdefault("ollama", types.SimpleNamespace(AsyncClient=None))

import src.app as app

class DummyStep:
    def __init__(self, name=None, type=None):
        self.name = name
        self.type = type
        self.input = None
        self.output = None
    async def __aenter__(self):
        return self
    async def __aexit__(self, exc_type, exc, tb):
        pass
    async def stream_token(self, token):
        pass
app.cl.Step = DummyStep

class DummyAsyncClient:
    def chat(self, model, messages, stream, options):
        self.messages = messages
        class Response:
            def __init__(self): pass
            def __await__(self):
                async def _wrap(): return self
                return _wrap().__await__()
            def __aiter__(self):
                async def gen():
                    yield {"message": {"content": "Final Answer: ok"}}
                return gen()
        return Response()

client = DummyAsyncClient()
app.ollama.AsyncClient = lambda: client

agent = app.ReActAgent()
agent.max_iterations = 1
asyncio.run(agent._execute_react_loop("Test question", []))
print(client.messages[0])
print(agent.conversation_history[0])
PY`

------
https://chatgpt.com/codex/tasks/task_e_689efd964ce8832db0a21581e578a055