### PR TITLE
Ensure final answer includes last tool observation

### DIFF
--- a/tests/test_react_loop.py
+++ b/tests/test_react_loop.py
@@ -46,12 +46,12 @@ class DummyStep:
 
 
 class DummyAsyncClient:
-    """Mock of ollama.AsyncClient streaming a preset response."""
+    """Mock of ollama.AsyncClient streaming preset responses per call."""
 
-    tokens = []
+    responses = []
 
     def chat(self, model, messages, stream, options):
-        tokens = list(self.tokens)
+        tokens = list(self.responses.pop(0) if self.responses else [])
 
         class Response:
             def __init__(self, toks):
@@ -76,7 +76,7 @@ def test_direct_answer_exits_in_one_iteration(monkeypatch):
     monkeypatch.setattr(app.ollama, "AsyncClient", DummyAsyncClient)
 
     DummyStep.calls = []
-    DummyAsyncClient.tokens = ["Paris is the capital of France."]
+    DummyAsyncClient.responses = [["Paris is the capital of France."]]
 
     agent = ReActAgent()
     result = asyncio.run(agent._execute_react_loop("What is the capital of France?", []))
@@ -84,4 +84,28 @@ def test_direct_answer_exits_in_one_iteration(monkeypatch):
     assert result == "Paris is the capital of France."
     reasoning_cycles = [n for n in DummyStep.calls if n and n.startswith("Reasoning Cycle")]
     assert len(reasoning_cycles) == 1
+
+
+def test_directory_listing_appended_to_final_answer(monkeypatch):
+    """Ensure directory listings are included in the final response."""
+    monkeypatch.setattr(app, "cl", types.SimpleNamespace(Step=DummyStep))
+    monkeypatch.setattr(app.ollama, "AsyncClient", DummyAsyncClient)
+
+    DummyStep.calls = []
+    DummyAsyncClient.responses = [
+        [
+            "<tool_call>{\"name\": \"list_directory\", \"arguments\": {\"path\": \".\"}}</tool_call>"
+        ],
+        ["Final Answer: done"],
+    ]
+
+    async def fake_execute(tool_name, tool_args):
+        return "file1\nfile2"
+
+    monkeypatch.setattr(app, "execute_tool_call", fake_execute)
+
+    agent = ReActAgent()
+    result = asyncio.run(agent._execute_react_loop("List directory", []))
+
+    assert "file1\nfile2" in result
 


### PR DESCRIPTION
## Summary
- Track the most recent tool observation inside `_execute_react_loop`
- Append the last observation to the final answer if it isn't mentioned
- Add regression test ensuring directory listings are included in final responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f095a08c8832dba35b65187625d8a