### PR TITLE
feat: add conversation summary logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import chainlit as cl
 import uuid
 import asyncio
 from src.local_agent.agent import create_agent_executor
+from src.conversation_logger import log_conversation_summary
 
 # --- Global State for One-Time Model Loading ---
 MODEL_LOAD_LOCK = asyncio.Lock()
@@ -92,7 +93,8 @@ async def on_message(message: cl.Message):
             # No thinking tags, just send the content
             msg = cl.Message(content=full_content, author="David")
             await msg.send()
-        
+        # After handling the message, log the conversation so far
+        log_conversation_summary(session_id)
     except Exception as e:
         error_msg = f"Error: {str(e)}"
         await cl.Message(content=error_msg, author="David").send()

--- a/src/conversation_logger.py
+++ b/src/conversation_logger.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from pathlib import Path
+
+from src.local_agent.agent import session_histories
+
+
+def log_conversation_summary(session_id: str, file_path: str = "conversation_logs.txt") -> None:
+    """Append a simple summary of the conversation to ``file_path``.
+
+    The summary lists all messages in the conversation so far. Each call will
+    write the current state of the conversation for ``session_id``.
+    """
+    history = session_histories.get(session_id)
+    if history is None:
+        return
+
+    lines = []
+    for message in history.messages:
+        role = "User" if message.type == "human" else "AI"
+        lines.append(f"{role}: {message.content}")
+
+    summary = " | ".join(lines)
+    timestamp = datetime.utcnow().isoformat()
+    log_entry = f"{timestamp} - Session {session_id} - {summary}\n"
+
+    path = Path(file_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(log_entry)


### PR DESCRIPTION
## Summary
- log chat histories to a text file for later review
- invoke logging after each user message without altering existing LangChain agent

## Testing
- `python -m py_compile src/conversation_logger.py app.py`
- `python test_agent.py` *(fails: [Errno 111] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b188b6e4832d9383ac5c7b15830d