### PR TITLE
Add status_check utility for David configuration

### DIFF
--- a/src/local_agent/agent.py
+++ b/src/local_agent/agent.py
@@ -70,3 +70,31 @@ After thinking, provide your authentic response as David in natural text (no XML
     )
 
     return agent_with_memory, llm
+
+
+def status_check(llm=None):
+    """
+    Return David's current LLM configuration.
+
+    Args:
+        llm: Optional ChatOllama instance. If provided, values are taken
+            from this instance. Otherwise, defaults used during creation
+            are returned.
+
+    Returns:
+        dict: Mapping with model name, temperature, and context window.
+    """
+    if llm is not None:
+        model = getattr(llm, "model", None)
+        temperature = getattr(llm, "temperature", None)
+        context_window = getattr(llm, "num_ctx", None)
+    else:
+        model = os.getenv("OLLAMA_MODEL", "qwen3:14b")
+        temperature = 0.6
+        context_window = 8192
+
+    return {
+        "model_name": model,
+        "temperature": temperature,
+        "context_window": context_window,
+    }

--- a/tests/test_status_check.py
+++ b/tests/test_status_check.py
@@ -1,0 +1,19 @@
+from src.local_agent.agent import status_check
+
+
+class DummyLLM:
+    def __init__(self):
+        self.model = "dummy-model"
+        self.temperature = 0.5
+        self.num_ctx = 1024
+
+
+def test_status_check_with_llm_instance():
+    dummy = DummyLLM()
+    cfg = status_check(dummy)
+    assert cfg == {
+        "model_name": "dummy-model",
+        "temperature": 0.5,
+        "context_window": 1024,
+    }
+


### PR DESCRIPTION
## Summary
- Add `status_check` helper to expose model name, temperature and context window
- Include unit test for the new helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4b36d1ca4832db9554d5a62acb76a